### PR TITLE
Add deterministic W6A8 dispatches for M=40/48 5120x3072 GEMMs

### DIFF
--- a/csrc/torch_extension.cu
+++ b/csrc/torch_extension.cu
@@ -1240,6 +1240,19 @@ at::Tensor launch_w6a8_policy(at::Tensor const& a,
         1, RasterOrder::Heuristic, 1, 0, use_pdl);
   }
 
+  if (target_nk && m == 40 && n == 5120 && k == 3072) {
+    return launch_swapped<swapped::KernelW6A8_64x32x128Stage3Pingpong>(
+        a, b, sfa, sfb, m, n, k, alpha, device_index,
+        1, RasterOrder::AlongM, 1, 0, use_pdl);
+  }
+
+  if (target_nk && m == 48 && n == 5120 && k == 3072) {
+    return launch_swapped<
+        swapped::KernelW6A8_64x32x128Stage3StaticPingpong>(
+        a, b, sfa, sfb, m, n, k, alpha, device_index,
+        4, RasterOrder::AlongN, 1, sm_count, use_pdl);
+  }
+
   if (target_nk && m == 64) {
     if (n == 5120 && k == 3072) {
       return launch_normal<normal::KernelW6A8_64x64x128Stage4StaticPingpong>(

--- a/python/mxfp6/ops.py
+++ b/python/mxfp6/ops.py
@@ -685,7 +685,9 @@ def gemm_from_codes(
 
 def is_tuned_shape(m: int, n: int, k: int) -> bool:
     """Return whether a problem has an exact target-shape override."""
-    return m in TUNED_M and (n, k) in TUNED_NK
+    if m in TUNED_M and (n, k) in TUNED_NK:
+        return True
+    return m in (40, 48) and (n, k) == (5120, 3072)
 
 
 def is_available() -> bool:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -389,15 +389,18 @@ def test_small_w6a8_dispatch(mxfp6) -> None:
 
 
 def test_tuned_transition_gemm(mxfp6) -> None:
-    """Exercise native and mixed exact dispatch at M=32, 64, and 96."""
+    """Exercise native and mixed exact dispatch around batch transitions."""
     shapes = (
         (32, 8192, 5120),
+        (40, 5120, 3072),
+        (48, 5120, 3072),
         (64, 5120, 3072),
         (64, 5120, 8704),
         (96, 7168, 5120),
         (96, 17408, 5120),
     )
     for index, (m, n, k) in enumerate(shapes):
+        assert mxfp6.is_tuned_shape(m, n, k)
         a_codes, b_codes, sfa, sfb = make_problem(m, n, k, 3200 + index)
         actual = mxfp6.gemm(
             mxfp6.pack_operand(a_codes, sfa),


### PR DESCRIPTION
## Summary

Add two exact SM120 W6A8 dispatches for the `N=5120, K=3072` GEMM that
appears in the request-drain path:

- `M=40`: swapped `64x32x128` stage-3 Pingpong, swizzle 1, `AlongM`
- `M=48`: swapped `64x32x128` stage-3 static Pingpong, swizzle 4, `AlongN`

The shapes are marked as tuned so first-use autotuning does not replace these
validated deterministic choices. Other shapes keep the existing dispatch and
autotune behavior.

## Validation

RTX 5090 (SM120) shape-level measurements:

| Shape | Previous selected configuration | New dispatch | Improvement |
|---|---:|---:|---:|
| `(40, 5120, 3072)` | 18.708 us | 15.876 us | 17.84% |
| `(48, 5120, 3072)` | 18.268 us | 15.308 us | 19.34% |

The production dispatch matched the selected kernel output bit-for-bit for
both shapes. The packaged operator suite and multimodal structural/exact-match
checks also passed.

In a separate saturated 64-request multimodal serving replay (concurrency 32,
2x RTX 5090), three paired runs improved median p99 TPOT by 3.05% (paired
improvements: 2.70%, 7.53%, and 3.05%). Output throughput was non-inferior:
median +0.32%, with the worst paired regression -0.41%; mean TPOT improved
0.65%, and success rate was unchanged.

This PR also adds both shapes to the existing tuned-transition correctness
test and asserts that they are recognized as exact tuned shapes.

Local PR checks:

- `git diff --check`
- `python3 -m py_compile python/mxfp6/ops.py tests/test_ops.py`

## Scope and limitations

This is a shape-specific tail-latency optimization, not a general throughput
claim. The serving result is limited to the tested model, workload, batch
regime, and SM120 environment. The two shapes appeared only around six times
in the observed steady workload, so average throughput should be treated as
neutral.

The serving comparison used a fixed 2x RTX 5090 PCIe `NODE` pair. Baseline and
candidate also used the same existing CUTLASS runtime patch set, which isolates
the dispatch change but is not a clean-upstream reproduction. Since the tested
base, upstream has changed only `python/mxfp6/autotune.py`; the runtime files
modified here were unchanged. A clean upstream rebuild and shape-level rerun
are still recommended before generalizing the service evidence.
