### PR TITLE
Add faster M=16 W6A8 dispatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Each code uses its low six bits. UE8M0 byte `0x7f` represents scale 1.0.
 ## Runtime autotuning
 
 Unknown W6A8 shapes use first-use selection from precompiled native CUTLASS
-families. The default searches all 29 families through `M=512`, where that
+families. The default searches all 30 families through `M=512`, where that
 recovers the small/medium-prefill swapped-tile winners. Above `M=512`, it uses
 the stable normal-family shortlist: measured family gaps are small there, and
 ranking a much larger set from finite samples can select a lucky-but-slower

--- a/benchmarks/retune_runtime.py
+++ b/benchmarks/retune_runtime.py
@@ -177,7 +177,7 @@ def main() -> None:
 
     payload = {
         "schema_version": 1,
-        "candidate_abi": "native-w6a8-29-v4",
+        "candidate_abi": "native-w6a8-30-v5",
         "devices": list(options.devices),
         "batch_sizes": list(options.batch_sizes),
         "output_dtypes": list(options.output_dtypes),

--- a/csrc/include/mxfp6_gemm/kernel_swapped.hpp
+++ b/csrc/include/mxfp6_gemm/kernel_swapped.hpp
@@ -232,6 +232,13 @@ using KernelW6A8_64x16x256StaticPingpong = KernelConfig<
     cutlass::epilogue::collective::EpilogueTileAuto,
     cutlass::gemm::StaticPersistentScheduler, void,
     mxfp6_gemm::ElementPairB, ElementPairB8>;
+using KernelW6A8_64x16x128Stage3StaticPingpong = KernelConfig<
+    cute::_64, cute::_16, cute::_128,
+    cutlass::gemm::KernelTmaWarpSpecializedPingpongMxf8f6f4Sm120,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    cutlass::gemm::StaticPersistentScheduler,
+    cutlass::gemm::collective::StageCount<3>,
+    mxfp6_gemm::ElementPairB, ElementPairB8>;
 
 // M=32 portfolio. In the swapped orientation the logical activation batch is
 // the tile N dimension, so these kernels cover all 32 rows without either the

--- a/csrc/torch_extension.cu
+++ b/csrc/torch_extension.cu
@@ -1126,9 +1126,14 @@ at::Tensor launch_w6a8_config(at::Tensor const& a,
           swapped::KernelW6A8_128x32Stage2StaticCooperative>(
           a, b, sfa, sfb, m, n, k, alpha, device_index,
           swizzle_value, raster, 1, sm_count, use_pdl);
+    case 29:
+      return launch_swapped<
+          swapped::KernelW6A8_64x16x128Stage3StaticPingpong>(
+          a, b, sfa, sfb, m, n, k, alpha, device_index,
+          swizzle_value, raster, 1, sm_count, use_pdl);
   }
   TORCH_CHECK(false, "unknown W6A8 config_id ", config_id,
-              "; expected an integer in [0, 28]");
+              "; expected an integer in [0, 29]");
 }
 
 bool set_w6a8_config_cuda(at::Tensor const& anchor,
@@ -1152,8 +1157,8 @@ bool set_w6a8_config_cuda(at::Tensor const& anchor,
     w6a8_overrides.erase(key);
     return true;
   }
-  TORCH_CHECK(config_id <= 28,
-              "config_id must be in [0, 28], or negative to erase; got ",
+  TORCH_CHECK(config_id <= 29,
+              "config_id must be in [0, 29], or negative to erase; got ",
               config_id);
   check_swizzle(swizzle);
   parse_raster_order(raster_order);
@@ -1163,7 +1168,7 @@ bool set_w6a8_config_cuda(at::Tensor const& anchor,
 
 std::string w6a8_config_abi_cuda(at::Tensor const& anchor) {
   TORCH_CHECK(anchor.is_cuda(), "anchor must be a CUDA tensor");
-  return "native-w6a8-29-v4";
+  return "native-w6a8-30-v5";
 }
 
 // Native W6A8 dispatcher. The persistent B operand remains packed E3M2 while
@@ -1229,24 +1234,33 @@ at::Tensor launch_w6a8_policy(at::Tensor const& a,
 
   if (target_nk && m == 16) {
     if (n == 8192 && k == 5120) {
-      return launch_swapped<swapped::KernelW6A8_64x16x256StaticPingpong>(
+      return launch_swapped<
+          swapped::KernelW6A8_64x16x128Stage3StaticPingpong>(
           a, b, sfa, sfb, m, n, k, alpha, device_index,
-          2, RasterOrder::AlongM, 1, sm_count, use_pdl);
+          2, RasterOrder::AlongN, 1, sm_count, use_pdl);
     }
     if (n == 5120 && k == 3072) {
-      return launch_swapped<swapped::KernelW6A8_64x16x256StaticPingpong>(
+      return launch_swapped<
+          swapped::KernelW6A8_64x16x128Stage3StaticPingpong>(
           a, b, sfa, sfb, m, n, k, alpha, device_index,
-          2, RasterOrder::AlongM, 1, sm_count, use_pdl);
+          2, RasterOrder::AlongN, 1, sm_count, use_pdl);
     }
     if (n == 7168 && k == 5120) {
-      return launch_swapped<swapped::KernelW6A8_64x16x256StaticPingpong>(
+      return launch_swapped<
+          swapped::KernelW6A8_64x16x128Stage3StaticPingpong>(
           a, b, sfa, sfb, m, n, k, alpha, device_index,
-          4, RasterOrder::AlongM, 1, sm_count, use_pdl);
+          1, RasterOrder::AlongM, 1, sm_count, use_pdl);
     }
     if (n == 17408 && k == 5120) {
       return launch_swapped<swapped::KernelW6A8_128x16Stage4StaticCooperative>(
           a, b, sfa, sfb, m, n, k, alpha, device_index,
           1, RasterOrder::AlongM, 1, sm_count, use_pdl);
+    }
+    if (n == 5120 && k == 8704) {
+      return launch_swapped<
+          swapped::KernelW6A8_64x16x128Stage3StaticPingpong>(
+          a, b, sfa, sfb, m, n, k, alpha, device_index,
+          2, RasterOrder::AlongN, 1, sm_count, use_pdl);
     }
     return launch_swapped<swapped::KernelW6A8_64x16x256StaticPingpong>(
         a, b, sfa, sfb, m, n, k, alpha, device_index,

--- a/python/mxfp6/autotune.py
+++ b/python/mxfp6/autotune.py
@@ -29,7 +29,7 @@ from ._loader import load_library
 
 
 AUTOTUNE_SCHEMA = 1
-CANDIDATE_ABI = "native-w6a8-29-v4"
+CANDIDATE_ABI = "native-w6a8-30-v5"
 CANDIDATE_POLICY = "hybrid-all-families-through-m512-v2"
 TIMING_POLICY = "gemm-cuda-events-two-stage-v4"
 FALLBACK_CONFIG_ID = -1
@@ -68,6 +68,7 @@ KERNEL_NAMES = (
     "swapped_128x32_stage2_cooperative",
     "swapped_128x32_static_cooperative",
     "swapped_128x32_stage2_static_cooperative",
+    "swapped_64x16x128_stage3_static_pingpong",
 )
 RASTER_NAMES = ("heuristic", "along_m", "along_n")
 SWIZZLES = (1, 2, 4, 8)
@@ -413,7 +414,7 @@ def _kernel_ids(m: int, k: int) -> tuple[int, ...]:
     if m <= _all_families_max_m():
         kernels = list(range(len(KERNEL_NAMES)))
     elif m <= 16:
-        kernels = [0, 1, 2, 3, 4, 5]
+        kernels = [0, 1, 2, 3, 4, 5, 29]
     elif m <= 32:
         kernels = [
             4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16,

--- a/python/mxfp6/metadata.json
+++ b/python/mxfp6/metadata.json
@@ -9,6 +9,6 @@
   "scale_vector_size": 32,
   "accumulator_dtype": "float32",
   "output_dtype": ["float16", "bfloat16"],
-  "autotune_candidate_abi": "native-w6a8-29-v4",
+  "autotune_candidate_abi": "native-w6a8-30-v5",
   "cutlass_commit": "e6233cbac5d7c7a865c19c91cd684ceece19513c"
 }

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -174,7 +174,7 @@ def test_w6a8_candidate_registry(mxfp6) -> None:
     a6 = mxfp6.pack_operand(a_codes, sfa)
     b = mxfp6.pack_operand(b_codes, sfb)
     a8 = torch.ops.mxfp6.expand_fp6_to_fp8(a6.values, m, k)
-    assert torch.ops.mxfp6.w6a8_config_abi(a8) == "native-w6a8-29-v4"
+    assert torch.ops.mxfp6.w6a8_config_abi(a8) == "native-w6a8-30-v5"
     for out_dtype in (torch.float16, torch.bfloat16):
         torch.ops.mxfp6.set_w6a8_config(
             a8, m, n, k, -1, 1, 0, out_dtype
@@ -183,7 +183,7 @@ def test_w6a8_candidate_registry(mxfp6) -> None:
             a8, b.values, a6.scales, b.scales, m, n, k, 1.0, out_dtype
         )
         assert reference.dtype == out_dtype
-        for config_id in range(29):
+        for config_id in range(30):
             actual = torch.ops.mxfp6.gemm_w6a8_config(
                 a8,
                 b.values,
@@ -519,9 +519,11 @@ def test_small_w6a8_dispatch(mxfp6) -> None:
     shapes = (
         (1, 5120, 3072),    # 128x8, five-stage cooperative
         (1, 5120, 8704),    # 128x8 Stream-K
-        (16, 8192, 5120),   # 64x16x256 ping-pong
+        (16, 8192, 5120),   # 64x16x128 stage-3 ping-pong
+        (16, 5120, 3072),   # 64x16x128 stage-3 ping-pong
+        (16, 7168, 5120),   # 64x16x128 stage-3 ping-pong
         (16, 17408, 5120),  # 128x16 cooperative
-        (16, 5120, 8704),   # deep-K exact 64x16x256 policy
+        (16, 5120, 8704),   # deep-K 64x16x128 stage-3 ping-pong
     )
     for index, (m, n, k) in enumerate(shapes):
         a_codes, b_codes, sfa, sfb = make_problem(m, n, k, 1800 + index)


### PR DESCRIPTION
## What changed

- Add the swapped mixed-format `64x16x128` Stage-3 static-persistent ping-pong kernel to the native W6A8 portfolio.
- Use it for four profiled Qwen TP2 `M=16` projections while retaining the existing `128x16` kernel for `(16,17408,5120)`.
- Register the kernel as candidate 29 and bump the candidate ABI so persistent autotune caches cannot replay decisions from the previous 29-kernel set.
- Extend candidate-registry and exact-dispatch correctness coverage.

## Why

The existing M=16 policy used a `K=256` ping-pong tile for these projections. A bounded comparison found that the shallower `K=128`, Stage-3 variant consistently reduced the full activation-conversion-plus-GEMM path:

| shape `(M,N,K)` | full-path improvement |
|---|---:|
| `(16,8192,5120)` | 12.42% |
| `(16,5120,3072)` | 12.92% |
| `(16,7168,5120)` | 13.29% |
| `(16,5120,8704)` | 13.28% |

The measurements used 11 randomized paired trials with 50 iterations per trial on an RTX 5090 and included the FP6-to-FP8 activation conversion. `(16,17408,5120)` regressed with this kernel and therefore keeps its previous exact dispatch.

This is a small-M shape optimization, not a service-throughput claim. A balanced serving crossover did not resolve an end-to-end change beyond normal run-to-run variance.

## Validation

- `bash scripts/build_wheel.sh`
- Full `tests/test_ops.py` on SM120, covering FP16/BF16 candidate registration, all retained M=16 exact shapes, non-default streams, persistent workspace and CUDA Graph replay
- `python -m py_compile` for changed Python sources
- `git diff --check`
