### PR TITLE
Prepare the first public v0.1.1 release

### DIFF
--- a/.github/workflows/source-checks.yml
+++ b/.github/workflows/source-checks.yml
@@ -1,0 +1,74 @@
+name: Source checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Compile Python sources
+        run: python -m compileall -q python benchmarks tests tools
+      - name: Validate release metadata and JSON artifacts
+        run: |
+          python - <<'PY'
+          import ast
+          import json
+          import pathlib
+          import re
+
+          root = pathlib.Path(".")
+          project_version = re.search(
+              r'^version = "([^"]+)"$',
+              (root / "pyproject.toml").read_text(),
+              re.MULTILINE,
+          ).group(1)
+          metadata = json.loads(
+              (root / "python/mxfp6/metadata.json").read_text()
+          )
+          module = ast.parse((root / "python/mxfp6/__init__.py").read_text())
+          module_version = next(
+              ast.literal_eval(node.value)
+              for node in module.body
+              if isinstance(node, ast.Assign)
+              and any(
+                  isinstance(target, ast.Name) and target.id == "__version__"
+                  for target in node.targets
+              )
+          )
+          assert project_version == metadata["version"] == module_version
+
+          for artifact in (root / "benchmarks/results").glob("*.json"):
+              json.loads(artifact.read_text())
+
+          for required in (
+              "CHANGELOG.md",
+              "CONTRIBUTING.md",
+              "THIRD_PARTY_NOTICES.md",
+              "docs/compatibility.md",
+              "docs/checkpoint-format.md",
+              "docs/runtime-integration.md",
+          ):
+              assert (root / required).is_file(), required
+          PY
+      - name: Check whitespace
+        run: git diff --check HEAD^ HEAD
+      - name: Build source distribution through PEP 517
+        if: matrix.python-version == '3.12'
+        run: |
+          python -m pip install --disable-pip-version-check build
+          python -m build --sdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## 0.1.1 - 2026-08-12
+
+First GitHub release, covering both dense and Qwen3.5 MoE execution on SM120.
+
+### Added
+
+- native W6A8 dense GEMM with packed E3M2 weights and dynamic E4M3 activations;
+- deterministic small-shape dispatch, deployment-safe autotune cache policy
+  and persistent Stream-K workspace planning;
+- allocation-free Qwen3.5-35B-A3B MoE layer schedules for TP2 CUDA Graph use;
+- reviewed dense and MoE benchmark manifests;
+- explicit compatibility, checkpoint-format and vLLM/SGLang integration
+  documentation;
+- source metadata checks and third-party notices.
+
+### Compatibility boundary
+
+- exact SM120 only;
+- source build against the active PyTorch CUDA ABI;
+- no stable serialized checkpoint format or runtime loader yet;
+- no supported vLLM or SGLang serving integration in this release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+## Scope
+
+Contributions should improve the SM120 kernel package, its public operator
+contracts, or reproducible integration evidence. Runtime-specific adapters
+must remain narrowly versioned and must not make this package import private
+vLLM or SGLang modules.
+
+## Development checks
+
+Initialize the pinned CUTLASS submodule, apply the runtime patches and build
+against the PyTorch installation that will run the tests:
+
+```bash
+git submodule update --init --depth 1 third_party/cutlass
+bash scripts/apply_cutlass_patches.sh --runtime-only
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+ctest --test-dir build --output-on-failure
+pytest -q tests/test_ops.py
+```
+
+Before submitting a documentation or packaging-only change, run:
+
+```bash
+python -m compileall -q python benchmarks tests tools
+git diff --check
+python -m build --sdist
+```
+
+## Kernel changes
+
+A performance change must include:
+
+- a correctness oracle and the shapes, dtypes and routes it covers;
+- eager and CUDA Graph replay where the production path captures graphs;
+- paired measurements against the current implementation on the same GPU;
+- raw samples, environment identity and an explanation of the physical
+  mechanism;
+- a clearly bounded claim: kernel, layer or end-to-end service.
+
+Do not promote a microbenchmark winner as a serving result. Regressions or
+long-tail-only improvements should be reported explicitly rather than hidden
+inside an aggregate.
+
+## Public artifacts
+
+Do not commit private checkpoints, datasets, hostnames, credentials or internal
+runtime patches. Public benchmark results must identify a reproducible model or
+conversion recipe and include only redistributable metadata.
+
+Changes to operator schemas, packed layouts or checkpoint plans must update the
+relevant document under `docs/` and the changelog.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
-include CMakeLists.txt README.md LICENSE
+include CMakeLists.txt README.md LICENSE CHANGELOG.md CONTRIBUTING.md THIRD_PARTY_NOTICES.md
 include .gitmodules
+recursive-include docs *.md
 include scripts/build_wheel.sh scripts/build_profiler.sh scripts/apply_cutlass_patches.sh
-recursive-include csrc *.hpp *.h *.cu *.cpp
+recursive-include csrc *.hpp *.cu
 recursive-include patches *.patch *.md
 recursive-include third_party/cutlass/include *
 recursive-include third_party/cutlass/tools/util/include *

--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@ Native mixed-precision GEMM for NVIDIA Blackwell GeForce SM120:
 D[M, N] = A[M, K] @ B[N, K].T
 ```
 
+> [!IMPORTANT]
+> This project is an experimental, SM120-only PyTorch kernel package. It
+> provides dense and Qwen3.5 MoE layer APIs and reproducible kernel/layer
+> benchmarks. It does **not** yet provide a versioned Hugging Face checkpoint
+> format or converter, a vLLM model loader, or an SGLang quantization backend.
+> Installing the wheel alone does not make `vllm serve` or SGLang load an
+> MXFP6 checkpoint.
+
+Community integration status and the exact remaining contracts are documented
+in:
+
+- [`docs/compatibility.md`](docs/compatibility.md) — supported and measured
+  environments;
+- [`docs/checkpoint-format.md`](docs/checkpoint-format.md) — current in-memory
+  layout versus the missing persistent checkpoint contract;
+- [`docs/runtime-integration.md`](docs/runtime-integration.md) — vLLM and
+  SGLang delivery plan and acceptance bar.
+
+Contributions should follow [`CONTRIBUTING.md`](CONTRIBUTING.md), especially
+the correctness and provenance requirements for performance changes.
+
 Persistent weights are bit-packed E3M2 with one UE8M0 scale per 32 values.
 FP16 or BF16 activations are dynamically mapped 16-to-8 into E4M3/UE8M0 and
 consumed by a native CUTLASS W6A8 kernel. Accumulation is FP32 and output is
@@ -21,7 +42,8 @@ also keeps a packed-MXFP6 activation compatibility API for existing callers.
 The following results were measured on one NVIDIA GeForce RTX 5090 using:
 
 - PyTorch `2.11.0+cu130`, CUDA 13.0;
-- vLLM `0.20.3.dev4+ge38d84f55.d20260715`;
+- vLLM `0.20.3.dev4+ge38d84f55.d20260715` from a locally patched development
+  environment (not an upstream compatibility claim);
 - external Humming reference revision `694298e9`;
 - Qwen3.5-27B TP2 linear shapes, five `(N,K)` pairs per batch;
 - BF16 activation input, FP16 output, warm cache, 20 warmups and 100 measured
@@ -64,6 +86,8 @@ bits. It is a kernel-performance comparison, not a claim that the numerical
 formats or weight footprints are identical. Full dispatch and measurement
 metadata are recorded in
 [`benchmarks/results/native_w6a8_dispatch.json`](benchmarks/results/native_w6a8_dispatch.json).
+These measurements do not establish compatibility with an unmodified release
+of vLLM or SGLang.
 
 ### Qwen3.5-35B-A3B MoE
 
@@ -166,6 +190,10 @@ cooperative, static-persistent and selective Stream-K scheduling.
 - Ninja is recommended.
 
 CUTLASS is pinned at `e6233cbac5d7c7a865c19c91cd684ceece19513c`.
+The extension is built from source against the active PyTorch ABI; the project
+does not currently publish portable CUDA binary wheels. See the
+[compatibility policy](docs/compatibility.md) before integrating it into a
+runtime image.
 
 ## Installation
 
@@ -476,6 +504,7 @@ csrc/                  CUDA/C++ kernels and quantizers
 python/mxfp6/          Python API and persistent autotuner
 benchmarks/            GEMM, baseline and search tools
 benchmarks/results/    Reviewed dispatch and measurement metadata
+docs/                   Compatibility and runtime-delivery contracts
 tests/                 CUDA correctness and stream tests
 patches/cutlass/       Versioned SM120 CUTLASS fixes
 scripts/               Build and patch helpers
@@ -485,4 +514,4 @@ third_party/           Pinned CUTLASS submodule
 ## License
 
 The project is released under the BSD 3-Clause License. CUTLASS retains its
-upstream license.
+upstream license. See [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,21 @@
+# Third-party notices
+
+## NVIDIA CUTLASS
+
+This repository pins NVIDIA CUTLASS at commit
+`e6233cbac5d7c7a865c19c91cd684ceece19513c` as a Git submodule and carries
+three source patches under `patches/cutlass/`.
+
+CUTLASS is copyright NVIDIA Corporation and affiliates and is distributed
+under the BSD 3-Clause License. A copy of that license is included in built
+packages as `mxfp6/CUTLASS_LICENSE.txt`.
+
+The checked-in CUTLASS patches are modifications maintained by this project;
+they do not imply endorsement by NVIDIA.
+
+## Humming benchmark reference
+
+The reviewed benchmark metadata contains historical comparison measurements
+against `inclusionAI/humming` at revision
+`694298e9eb25ffdfc088353b49ba537ebf304479`. Humming source code is not copied,
+vendored, linked or distributed by this project.

--- a/docs/checkpoint-format.md
+++ b/docs/checkpoint-format.md
@@ -1,0 +1,52 @@
+# Checkpoint format status
+
+## Current contract
+
+Version 0.1.1 defines an in-memory operator representation, not a persistent
+model checkpoint format.
+
+`PackedMXFP6Tensor` contains:
+
+- `values`: contiguous CUDA `uint8` bytes containing four E3M2 values in three
+  bytes;
+- `scales`: contiguous CUDA `uint8` UE8M0 scales in the physical layout used by
+  the SM120 kernels;
+- `rows` and `k`: the logical two-dimensional matrix shape;
+- optional `logical_scales`: row-major `[rows, k / 32]` UE8M0 scales retained
+  by `pack_operand` for round-trip inspection.
+
+Each scale covers 32 consecutive values along K. `pack_operand` converts
+logical E3M2 codes and row-major scales into the kernel layout;
+`unpack_operand` reverses that transformation. These APIs are suitable for
+tests and process-local weight preparation.
+
+## What is deliberately not specified
+
+The physical tensors above must not yet be treated as a stable safetensors or
+Hugging Face checkpoint ABI. This release does not define:
+
+- `config.json` recognition fields or a quantization method identifier;
+- tensor names for packed values and scales;
+- padding and sharding rules for tensor, pipeline or expert parallelism;
+- fused projection ordering and model-specific tensor mapping;
+- a converter, validator or deterministic round-trip manifest;
+- forward compatibility across package minor versions.
+
+The Qwen3.5 benchmark contains a model-specific reader for local research
+checkpoints. It is benchmark code, not a supported loader.
+
+## Acceptance bar for checkpoint format v1
+
+A future persistent format must include all of the following before a vLLM or
+SGLang loader is published:
+
+1. a versioned quantization section declaring E3M2 weights, UE8M0 scales,
+   group size 32, byte order, padding and fused-projection ordering;
+2. deterministic tensor-name and TP/PP/EP sharding rules;
+3. a converter from a public source model or a publicly reproducible recipe;
+4. a CPU-readable metadata validator that does not require an SM120 GPU;
+5. conversion and load round-trip tests with checksums;
+6. an explicit policy for unknown versions and unsupported platforms.
+
+Until that contract exists, runtime adapters must fail with a clear
+unsupported-checkpoint error instead of guessing a layout.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,55 @@
+# Compatibility
+
+## Project scope
+
+`mxfp6-sm120` is a source-built PyTorch CUDA extension for NVIDIA compute
+capability 12.0. The public compatibility boundary is the Python and
+`torch.ops.mxfp6` API in this repository. vLLM and SGLang are optional
+benchmark/integration consumers, not package dependencies.
+
+## Supported boundary
+
+| Component | Current policy |
+|---|---|
+| GPU | Exactly SM120. Other compute capabilities fail closed at runtime. |
+| OS | Linux. Other operating systems are not supported. |
+| CUDA Toolkit | 12.8 or newer; the release is compiled for `sm_120a`. |
+| PyTorch | CUDA-enabled PyTorch with FP8 dtype support. Build the extension against the exact PyTorch ABI used at runtime. |
+| Python | 3.10 or newer. |
+| CUTLASS | Pinned submodule commit `e6233cbac5d7c7a865c19c91cd684ceece19513c` plus the checked-in runtime patches. |
+| Distribution | Source wheel only. No cross-PyTorch or cross-CUDA binary compatibility is promised. |
+
+The build intentionally rejects an uninitialized or mismatched CUTLASS
+checkout. The Python API checks CUDA placement, dtype, contiguity, shape and
+SM120 capability before dispatch.
+
+## Measured environment
+
+The reviewed dense benchmark manifest was produced on an RTX 5090 with
+PyTorch `2.11.0+cu130` and CUDA 13.0. The checked-in Qwen3.5 results are
+kernel/layer measurements on RTX 5090 GPUs. They are evidence for the declared
+operators and shapes, not a compatibility promise for arbitrary framework or
+model revisions.
+
+Some development measurements used a locally patched vLLM environment. Do not
+interpret them as results from an unmodified community vLLM release. A runtime
+integration must record its exact vLLM or SGLang commit, extension wheel hash,
+checkpoint revision and launch command.
+
+## Runtime status
+
+| Consumer | Dense operator | Qwen3.5 MoE layer | Checkpoint loader | Supported serving integration |
+|---|---:|---:|---:|---:|
+| PyTorch package | Yes | Experimental | No | Not applicable |
+| vLLM | Benchmark use only | Benchmark use only | No | No |
+| SGLang | Not integrated | Not integrated | No | No |
+
+See [runtime integration](runtime-integration.md) for the work required to
+change the last column.
+
+## Upgrade policy
+
+Until a 1.0 release, CUDA operator schemas, workspace layouts and Qwen-specific
+APIs may change between minor releases. Patch releases must remain compatible
+within their minor line. Applications should pin both the package version and
+the source commit.

--- a/docs/runtime-integration.md
+++ b/docs/runtime-integration.md
@@ -1,0 +1,77 @@
+# vLLM and SGLang integration status
+
+## Current verdict
+
+This repository is ready to be reviewed as an SM120 kernel package and layer
+benchmark reference. It is not yet a drop-in serving backend for vLLM or
+SGLang. The missing work is at the checkpoint, loader, model and runtime
+boundaries rather than in installation prose.
+
+## vLLM
+
+Current vLLM main provides an `MxFp6LinearKernel` backend interface and an
+out-of-tree kernel registration mechanism. Its own CPU test describes software
+emulation as the only available implementation at the time of this release.
+That interface is the preferred dense integration point for this project.
+
+A production contribution still needs:
+
+1. an SM120 backend implementing support checks, weight post-processing and
+   `apply_weights` without importing private benchmark code;
+2. a versioned checkpoint mapping and loader path;
+3. model-layer selection for dense projections and a separate MoE design;
+4. custom-op fake/meta behavior where required by compilation and CUDA Graphs;
+5. exact unsupported-platform and unsupported-checkpoint behavior;
+6. upstream unit tests plus public full-model prefill/decode, TP and graph
+   validation.
+
+The Qwen3.5 TP2 adapter used during development is intentionally not shipped
+in this wheel. It is tied to a particular runtime tree and has not been reduced
+to a stable vLLM extension contract.
+
+## SGLang
+
+SGLang exposes its own `QuantizationConfig`, linear and fused-MoE integration
+contracts. It currently has no MXFP6 backend in its quantization registry.
+Integration therefore requires a separate design and PR covering:
+
+1. quantization config recognition and capability gating;
+2. serialized weight creation/loading and post-load packing;
+3. linear and Qwen3.5 fused-MoE dispatch;
+4. CUDA Graph/custom-op integration and fallback behavior;
+5. SGLang-native correctness, accuracy and serving benchmarks.
+
+The vLLM adapter must not be copied into SGLang: their model, MoE and graph
+interfaces differ.
+
+## Required evidence for an upstream runtime PR
+
+- a public, checksummed checkpoint conversion or conversion recipe;
+- a pinned CUDA, PyTorch, runtime and model compatibility matrix;
+- package build/install smoke tests in a clean Linux environment;
+- config detection, tensor mapping, packing and dispatch unit tests;
+- full-model prefill and decode under CUDA Graphs and TP2;
+- public quality results with a stated acceptance threshold;
+- end-to-end serving throughput, TTFT and TPOT against a reproducible baseline;
+- raw commands and artifacts, with every claim limited to its measured scope.
+
+Kernel and layer speedups alone are useful evidence, but they do not satisfy
+this runtime acceptance bar.
+
+## Recommended sequence
+
+1. Freeze checkpoint format v1 and add a converter plus CPU metadata validator
+   in this repository.
+2. Implement the vLLM dense backend against its public MXFP6 kernel interface,
+   then add the narrow Qwen3.5 MoE path.
+3. Validate one model revision and SM120 TP2 configuration end to end before
+   proposing upstream support.
+4. Implement and validate SGLang independently after the format stabilizes.
+
+## Upstream references
+
+- [vLLM MXFP6 kernel interface](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/kernels/linear/mxfp6/base.py)
+- [vLLM kernel selection test](https://github.com/vllm-project/vllm/blob/main/tests/kernels/quantization/test_mxfp6_kernel_selection.py)
+- [vLLM quantization configuration contract](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/quantization/base_config.py)
+- [SGLang quantization configuration contract](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/quantization/base_config.py)
+- [SGLang MXFP4 reference implementation](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/quantization/mxfp4.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
 ]
 
+[project.urls]
+Homepage = "https://github.com/Nekofish-L/mxfp6_sm120"
+Repository = "https://github.com/Nekofish-L/mxfp6_sm120"
+Issues = "https://github.com/Nekofish-L/mxfp6_sm120/issues"
+
 [tool.setuptools]
 package-dir = {"" = "python"}
 


### PR DESCRIPTION
## Summary

- state the SM120 kernel package and runtime-integration boundary explicitly
- document compatibility, current in-memory MXFP6 layout, and vLLM/SGLang acceptance requirements
- add contributing/release/third-party documentation and source-only CI
- keep the existing package version `0.1.1` for the first GitHub release

## Validation

- Python 3.12 `compileall` over package, benchmarks, tests, and tools
- version/JSON/local Markdown-link checks
- workflow YAML parse
- `git diff --check`
- PEP 517 sdist build, including docs and CUTLASS license

No CUDA source changed, so the previously reviewed kernel and layer performance artifacts remain the release evidence.